### PR TITLE
Lazy load android context.

### DIFF
--- a/clipboard.android.js
+++ b/clipboard.android.js
@@ -1,11 +1,18 @@
 var application = require("application");
-var context = application.android.context;
+
+var _context;
+function getContext() {
+  if(!_context){
+    _context = application.android.context;
+  }
+  return _context;
+}
 
 exports.setText = function (content) {
   return new Promise(function (resolve, reject) {
     try {
       // copy to clipboard
-      var clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE);
+      var clipboard = getContext().getSystemService(android.content.Context.CLIPBOARD_SERVICE);
       var clip = android.content.ClipData.newPlainText("App clipboard data", content);
       clipboard.setPrimaryClip(clip);
       resolve();
@@ -19,7 +26,7 @@ exports.setText = function (content) {
 exports.getText = function () {
   return new Promise(function (resolve, reject) {
     try {
-      var clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE);
+      var clipboard = getContext().getSystemService(android.content.Context.CLIPBOARD_SERVICE);
       if (!clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_PLAIN)) {
         reject("No compatible clipboard content found");
       } else {


### PR DESCRIPTION
If this module is required before application startup (for example in app.js) the `application.android.context` might not be initialized yet.
Solution: Load the context then the module is first used.

Fixes #2 