### PR TITLE
Support reading HTML text from clipboard

### DIFF
--- a/src/clipboard.android.ts
+++ b/src/clipboard.android.ts
@@ -36,7 +36,8 @@ export function getText(): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     try {
       const clipboard = Utils.ad.getApplicationContext().getSystemService(android.content.Context.CLIPBOARD_SERVICE);
-      if (!clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+      if (!clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_PLAIN) &&
+          !clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_HTML)) {
         reject("No compatible clipboard content found");
       } else {
         resolve(readFromClipboard(clipboard));
@@ -51,7 +52,8 @@ export function getText(): Promise<string> {
 export function getTextSync(): string {
   try {
     const clipboard = Utils.ad.getApplicationContext().getSystemService(android.content.Context.CLIPBOARD_SERVICE);
-    if (!clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+    if (!clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_PLAIN) &&
+        !clipboard.getPrimaryClipDescription().hasMimeType(android.content.ClipDescription.MIMETYPE_TEXT_HTML)) {
       console.log("No compatible clipboard content found");
       return "";
     } else {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Returns empty string when reading HTML text.

## What is the new behavior?
Some apps write HTML instead of text to clipboard which could be converted to text too.
Returns converted text from HTMl when reading HTML text.


